### PR TITLE
Bump version to 1.10.15post1 for custom release

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.15'
+version = '1.10.15post1'


### PR DESCRIPTION
Bumps version from 1.10.15 to 1.10.15post1 following Step 1 in the instructions [here](https://github.com/lyft/airflow/pull/new/bump_version_20220923).