### PR TITLE
Add . to the post version

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.15post1'
+version = '1.10.15.post1'


### PR DESCRIPTION
Change the version from 1.10.15post1 to 1.10.15.post1 following conventions [here](https://peps.python.org/pep-0440/#post-release-separators).