### PR TITLE
Bump version to Airflow 1.10.15.post2

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.15.post1'
+version = '1.10.15.post2'


### PR DESCRIPTION
Bump version to Airflow 1.10.15.post2 to avoid confusion with the old 1.10.15post1 (which did not contain a `.`).