### PR TITLE
Fix sync-to-db command with 2.3.4 decorator

### DIFF
--- a/airflow/cli/commands/sync_to_db_command.py
+++ b/airflow/cli/commands/sync_to_db_command.py
@@ -20,7 +20,7 @@ from airflow.models import DagBag
 from airflow.utils import cli as cli_utils
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli
 def sync_to_db(args): # noqa
     dag_bag = DagBag(store_serialized_dags=False)
     dag_bag.sync_to_db()

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post1'
+version = '2.3.4.post2'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
Airflow CLI utils now wraps the `action_logging` function in an `action_cli` decorator. We need to update the decorator to reflect that change.

2.2.5: https://github.com/apache/airflow/blob/2.2.5/airflow/utils/cli.py 
2.3.4: https://github.com/apache/airflow/blob/2.3.4/airflow/utils/cli.py#L56

Attempting to run `kyte add` in Kyte staging 2.3.4 gives 

```Traceback (most recent call last):
  File "/code/venvs/venv/bin/airflow", line 8, in <module>
    sys.exit(main())
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/__main__.py", line 38, in main
    args.func(args)
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/cli/cli_parser.py", line 50, in command
    func = import_string(import_path)
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/utils/module_loading.py", line 32, in import_string
    module = import_module(module_path)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/cli/commands/sync_to_db_command.py", line 23, in <module>
    @cli_utils.action_logging
AttributeError: module 'airflow.utils.cli' has no attribute 'action_logging'```