### PR TITLE
primary key is set to __airflow_tmp_xcom_pkey during downgrades

### DIFF
--- a/airflow/migrations/versions/0060_2_0_0_remove_id_column_from_xcom.py
+++ b/airflow/migrations/versions/0060_2_0_0_remove_id_column_from_xcom.py
@@ -118,7 +118,7 @@ def downgrade():
     conn = op.get_bind()
     with op.batch_alter_table('xcom') as bop:
         if conn.dialect.name != 'mssql':
-            bop.drop_constraint('pk_xcom', type_='primary')
+            bop.drop_constraint('__airflow_tmp_xcom_pkey', type_='primary')
         bop.add_column(Column('id', Integer, nullable=False))
         bop.create_primary_key('id', ['id'])
         bop.create_index('idx_xcom_dag_task_date', ['dag_id', 'task_id', 'key', 'execution_date'])


### PR DESCRIPTION
Unblocks:

`[2023-02-13 23:28:59,201] {db.py:1526} INFO - Attempting downgrade to revision cf5dc11e79ad
[2023-02-13 23:28:59,206] {db.py:1537} INFO - Applying downgrade migrations.
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade bbf4a7ad0465 -> cf5dc11e79ad, Remove id column from xcom
Traceback (most recent call last):
  File "/code/venvs/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1802, in _execute_context
    self.dialect.do_execute(
  File "/code/venvs/venv/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 719, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.UndefinedObject: constraint "pk_xcom" of relation "xcom" does not exist


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/code/venvs/venv/bin/airflow", line 8, in <module>
    sys.exit(main())
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/__main__.py", line 38, in main
    args.func(args)
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/cli/cli_parser.py", line 51, in command
    return func(*args, **kwargs)
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/utils/cli.py", line 99, in wrapper
    return f(*args, **kwargs)
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/cli/commands/db_command.py", line 127, in downgrade
    db.downgrade(to_revision=to_revision, from_revision=from_revision, show_sql_only=args.show_sql_only)
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/utils/session.py", line 71, in wrapper
    return func(*args, session=session, **kwargs)
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/utils/db.py", line 1538, in downgrade
    command.downgrade(config, revision=to_revision, sql=show_sql_only)
  File "/code/venvs/venv/lib/python3.8/site-packages/alembic/command.py", line 368, in downgrade
    script.run_env()
  File "/code/venvs/venv/lib/python3.8/site-packages/alembic/script/base.py", line 569, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/code/venvs/venv/lib/python3.8/site-packages/alembic/util/pyfiles.py", line 94, in load_python_file
    module = load_module_py(module_id, path)
  File "/code/venvs/venv/lib/python3.8/site-packages/alembic/util/pyfiles.py", line 110, in load_module_py
    spec.loader.exec_module(module)  # type: ignore
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/migrations/env.py", line 107, in <module>
    run_migrations_online()
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/migrations/env.py", line 101, in run_migrations_online
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/code/venvs/venv/lib/python3.8/site-packages/alembic/runtime/environment.py", line 853, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/code/venvs/venv/lib/python3.8/site-packages/alembic/runtime/migration.py", line 623, in run_migrations
    step.migration_fn(**kw)
  File "/code/venvs/venv/lib/python3.8/site-packages/airflow/migrations/versions/0060_2_0_0_remove_id_column_from_xcom.py", line 124, in downgrade
    bop.create_index('idx_xcom_dag_task_date', ['dag_id', 'task_id', 'key', 'execution_date'])
  File "/usr/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/code/venvs/venv/lib/python3.8/site-packages/alembic/operations/base.py", line 381, in batch_alter_table
    impl.flush()
  File "/code/venvs/venv/lib/python3.8/site-packages/alembic/operations/batch.py", line 111, in flush
    fn(*arg, **kw)
  File "/code/venvs/venv/lib/python3.8/site-packages/alembic/ddl/impl.py", line 338, in drop_constraint
    self._exec(schema.DropConstraint(const))
  File "/code/venvs/venv/lib/python3.8/site-packages/alembic/ddl/impl.py", line 195, in _exec
    return conn.execute(construct, multiparams)
  File "/code/venvs/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1289, in execute
    return meth(self, multiparams, params, _EMPTY_EXECUTION_OPTS)
  File "/code/venvs/venv/lib/python3.8/site-packages/sqlalchemy/sql/ddl.py", line 77, in _execute_on_connection
    return connection._execute_ddl(
  File "/code/venvs/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1381, in _execute_ddl
    ret = self._execute_context(
  File "/code/venvs/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1845, in _execute_context
    self._handle_dbapi_exception(
  File "/code/venvs/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 2026, in _handle_dbapi_exception
    util.raise_(
  File "/code/venvs/venv/lib/python3.8/site-packages/sqlalchemy/util/compat.py", line 207, in raise_
    raise exception
  File "/code/venvs/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1802, in _execute_context
    self.dialect.do_execute(
  File "/code/venvs/venv/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 719, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedObject) constraint "pk_xcom" of relation "xcom" does not exist

[SQL: ALTER TABLE xcom DROP CONSTRAINT pk_xcom]`
