### PR TITLE
only load dags in dagbag that have been migrated

### DIFF
--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -217,6 +217,9 @@ def _find_path_from_directory(
     migrated_dags_set = MIGRATED_DAG_FILES if os.environ.get("SERVICE_INSTANCE", "").lower() == "production" \
         else STAGING_MIGRATED_DAG_FILES
 
+    # set this rather than import from lyft_etl to avoid any circular import errors
+    is_airflow_dev_env = "kyte" in os.environ.get("SERVICE", "") or "tars" in os.environ.get("SERVICE", "")
+
     for root, dirs, files in os.walk(base_dir_path, followlinks=True):
         patterns: List[_IgnoreRule] = patterns_by_dir.get(Path(root).resolve(), [])
 
@@ -262,7 +265,7 @@ def _find_path_from_directory(
 
             # only load dag files that are already migrated
             # work around for poor negative look back regex performance
-            if str(abs_file_path) not in migrated_dags_set:
+            if not is_airflow_dev_env and str(abs_file_path) not in migrated_dags_set:
                 continue
 
             yield str(abs_file_path)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post5'
+version = '2.3.4.post6'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)
@@ -232,7 +232,7 @@ azure = [
     'azure-mgmt-datalake-store>=0.5.0',
     'azure-mgmt-resource>=2.2.0',
     # limited due to https://github.com/Azure/azure-sdk-for-python/pull/18801  implementation released in 12.9
-    'azure-storage-blob',  # Temporarily remove >=12.7.0,<12.9.0 restriction for lyft-regulatoryintegrations 
+    'azure-storage-blob',  # Temporarily remove >=12.7.0,<12.9.0 restriction for lyft-regulatoryintegrations
     'azure-storage-common>=2.1.0',
     'azure-storage-file>=2.1.0',
     # Limited due to https://github.com/Azure/azure-uamqp-python/issues/191


### PR DESCRIPTION
This is a work around for the poor regex negative look back performance to only load migrated DAGs in the Airflow 2 cluster.

Related PR: https://github.com/lyft/airflowinfra2/pull/109
