### PR TITLE
don't force fail on a sensor timeout

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1508,7 +1508,7 @@ class TaskInstance(Base, LoggingMixin):
             self._handle_reschedule(actual_start_date, reschedule_exception, test_mode, session=session)
             session.commit()
             return
-        except (AirflowFailException, AirflowSensorTimeout) as e:
+        except (AirflowFailException) as e:
             # If AirflowFailException is raised, task should not retry.
             # If a sensor in reschedule mode reaches timeout, task should not retry.
             self.handle_failure(e, test_mode, force_fail=True, error_file=error_file, session=session)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post8'
+version = '2.3.4.post9'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
The change to have AirflowSensorTimeout be a failing exception was made here: https://github.com/apache/airflow/pull/12058

Our users have the expectations that their sensor timeouts = timeout x num retries which differs from the logic of the update to sensor timeout behavior.

This has caused issues for some long running sensors for migrated DAGs - even sensors that don't have reschedule mode enabled (ie LyftHiveParitionSensor). This contrary to Airflow docs stating it only impacts sensors in reschedule mode and is the case based on the code.

Let's roll this out today so oncalls don't have to manually clear long running wait for tasks over the weekend/we don't have to rollback DAGs to Airflow 1.

I can rollback the update we made to the reschedule enabled sensors (LyftExternalTaskSensor) + the mutate sensors task policy after this rolls out. We can also have further discussions about moving all sensors to reschedule mode or deferred.