### PR TITLE
Add description column to variable

### DIFF
--- a/airflow/migrations/versions/b7a8283de53b_add_description_column_to_variable.py
+++ b/airflow/migrations/versions/b7a8283de53b_add_description_column_to_variable.py
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Add description column to Variable
+
+Revision ID: b7a8283de53b
+Revises: 03afc6b6f902
+Create Date: 2023-03-28 22:36:38.354244
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b7a8283de53b'
+down_revision = '03afc6b6f902'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('variable', sa.Column('description', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('variable', 'description')
+

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -39,6 +39,7 @@ class Variable(Base, LoggingMixin):
     id = Column(Integer, primary_key=True)
     key = Column(String(ID_LEN), unique=True)
     _val = Column('val', Text)
+    description = Column(Text)
     is_encrypted = Column(Boolean, unique=False, default=False)
 
     def __repr__(self):
@@ -76,7 +77,7 @@ class Variable(Base, LoggingMixin):
                        descriptor=property(cls.get_val, cls.set_val))
 
     @classmethod
-    def setdefault(cls, key, default, deserialize_json=False):
+    def setdefault(cls, key, default, description=None, deserialize_json=False):
         """
         Like a Python builtin dict object, setdefault returns the current value
         for a key, and if it isn't there, stores the default value and returns it.
@@ -86,6 +87,7 @@ class Variable(Base, LoggingMixin):
         :param default: Default value to set and return if the variable
             isn't already in the DB
         :type default: Mixed
+        :param description: Default value to set Description of the Variable
         :param deserialize_json: Store this as a JSON encoded value in the DB
             and un-encode it when retrieving a value
         :return: Mixed
@@ -94,7 +96,7 @@ class Variable(Base, LoggingMixin):
                            deserialize_json=deserialize_json)
         if obj is None:
             if default is not None:
-                Variable.set(key, default, serialize_json=deserialize_json)
+                Variable.set(key, default, description=description, serialize_json=deserialize_json)
                 return default
             else:
                 raise ValueError('Default Value must be set')
@@ -127,6 +129,7 @@ class Variable(Base, LoggingMixin):
         cls,
         key,  # type: str
         value,  # type: Any
+        description=None,  # type: str
         serialize_json=False,  # type: bool
         session=None
     ):
@@ -137,7 +140,7 @@ class Variable(Base, LoggingMixin):
             stored_value = str(value)
 
         Variable.delete(key, session=session)
-        session.add(Variable(key=key, val=stored_value))  # type: ignore
+        session.add(Variable(key=key, val=stored_value, description=description))  # type: ignore
         session.flush()
 
     @classmethod

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.15.post2'
+version = '1.10.15.post3'


### PR DESCRIPTION
We started syncing Variable writes to both the Airflow 1 and 2 metastores. However, the Variable table slightly differs between the 2 versions. This introduces issues given the current way we write variables to the Airflow 1 metastore from Airflow 2 as the column "description" does not exist in Airflow 1.

I believe adding the column to the Airflow 1 metastore is the simplest/cleanest fix.

An alternative could be to change how we write the variables from Airflow 2 to 1 by taking the logic from Variables.set in 1.10.15 + writing the sql itself and then adding that to lyft-etl util function. 
 