### PR TITLE
temp patch to load newly migrated Flyte workflows into Airflow 2

### DIFF
--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -275,9 +275,9 @@ def _find_path_from_directory(
                 # temp patch to load new Flyte workflows into Airflow 2 to unblock initial migration users
                 # this will be replaced soon with look-up tables for mult-cluster Airflow
                 dag_repo = str(abs_file_path).split("/")[4]
-                if dag_repo in MIGRATED_FLYTE_REPOS:
-                    pass
-                elif not (is_airflow_dev_env or is_loadtest_env) and str(abs_file_path) not in migrated_dags_set:
+                if not (is_airflow_dev_env or is_loadtest_env) and \
+                   dag_repo not in MIGRATED_FLYTE_REPOS and \
+                   str(abs_file_path) not in migrated_dags_set:
                     continue
 
             yield str(abs_file_path)

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -216,6 +216,7 @@ def _find_path_from_directory(
     if service_instance == 'production' or service_instance == 'staging':
         from airflowinfra.migrated_dag_files import MIGRATED_DAG_FILES
         from airflowinfra.staging_migrated_dag_files import STAGING_MIGRATED_DAG_FILES
+        from airflowinfra.migrated_flyte_repos import MIGRATED_FLYTE_REPOS
         migrated_dags_set = MIGRATED_DAG_FILES if service_instance == "production" \
             else STAGING_MIGRATED_DAG_FILES
 
@@ -271,7 +272,12 @@ def _find_path_from_directory(
             # only load dag files that are already migrated
             # work around for poor negative look back regex performance
             if service_instance == 'production' or service_instance == 'staging':
-                if not (is_airflow_dev_env or is_loadtest_env) and str(abs_file_path) not in migrated_dags_set:
+                # temp patch to load new Flyte workflows into Airflow 2 to unblock initial migration users
+                # this will be replaced soon with look-up tables for mult-cluster Airflow
+                dag_repo = str(abs_file_path).split("/")[4]
+                if dag_repo in MIGRATED_FLYTE_REPOS:
+                    pass
+                elif not (is_airflow_dev_env or is_loadtest_env) and str(abs_file_path) not in migrated_dags_set:
                     continue
 
             yield str(abs_file_path)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post10'
+version = '2.3.4.post11'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
Load new Flyte workflows from Flyte/DAG repos set in airflowinfra2. When PRs are created in airflowinfra2 to add a Flyte dag repo, we will require that that dag repo is removed from airflowinfra to ensure the workflows don't run in both Airflow clusters. This unblocks initial Flyte -> Airflow migration users. 

To note: this DAG loading logic to limit the dag_bag will be replaced with look-up tables to check dag_id in another step of the dag loading process as discussed in the multi-cluster Airflow spec. 