### PR TITLE
add is_multi_cluster_enabled param to block non wrapped variable writes

### DIFF
--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -167,10 +167,10 @@ class Variable(Base, LoggingMixin):
         :param session: SQL Alchemy Sessions
         :param is_multi_cluster_enabled: is set wrapped by lyft-etl sync_variable_writes_multicluster
         """
-        # check if the secret exists in the custom secrets backend.
         if not is_multi_cluster_enabled:
             raise AirflowFailException("Please write Airflow variables using "
                                        "sync_variable_writes_multicluster defined in lyft-etl")
+        # check if the secret exists in the custom secrets backend.
         cls.check_for_write_conflict(key)
         if serialize_json:
             stored_value = json.dumps(value, indent=2)

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -154,6 +154,7 @@ class Variable(Base, LoggingMixin):
         description: Optional[str] = None,
         serialize_json: bool = False,
         session: Session = None,
+        is_multi_cluster_enabled: bool = False,
     ):
         """
         Sets a value for an Airflow Variable with a given Key.
@@ -164,8 +165,12 @@ class Variable(Base, LoggingMixin):
         :param description: Description of the Variable
         :param serialize_json: Serialize the value to a JSON string
         :param session: SQL Alchemy Sessions
+        :param is_multi_cluster_enabled: is set wrapped by lyft-etl sync_variable_writes_multicluster
         """
         # check if the secret exists in the custom secrets backend.
+        if not is_multi_cluster_enabled:
+            raise AirflowFailException("Please write Airflow variables using "
+                                       "sync_variable_writes_multicluster defined in lyft-etl")
         cls.check_for_write_conflict(key)
         if serialize_json:
             stored_value = json.dumps(value, indent=2)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post11'
+version = '2.3.4.post12'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
This will help ensure that all Variable writes and made through our wrapping function in lyft_etl and will fail the write otherwise. 

This version bump in airflowinfra2 will be made along with the needed changes in lyft_etl. Can also make this change in airflow 1.

