### PR TITLE
Load all staging dags to Airflow 2

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -401,8 +401,6 @@ class DagBag(LoggingMixin):
         found_dags = []
 
         for (dag, mod) in top_level_dags:
-            if dag.dag_id != "test":
-                continue
             dag.fileloc = mod.__file__
             try:
                 dag.validate()

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -401,6 +401,8 @@ class DagBag(LoggingMixin):
         found_dags = []
 
         for (dag, mod) in top_level_dags:
+            if dag.dag_id != "test":
+                continue
             dag.fileloc = mod.__file__
             try:
                 dag.validate()

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -213,12 +213,9 @@ def _find_path_from_directory(
     # A Dict of patterns, keyed using resolved, absolute paths
 
     service_instance = os.environ.get('SERVICE_INSTANCE', '').lower()
-    if service_instance == 'production' or service_instance == 'staging':
+    if service_instance == 'production':
         from airflowinfra.migrated_dag_files import MIGRATED_DAG_FILES
-        from airflowinfra.staging_migrated_dag_files import STAGING_MIGRATED_DAG_FILES
         from airflowinfra.migrated_flyte_repos import MIGRATED_FLYTE_REPOS
-        migrated_dags_set = MIGRATED_DAG_FILES if service_instance == "production" \
-            else STAGING_MIGRATED_DAG_FILES
 
     patterns_by_dir: Dict[Path, List[_IgnoreRule]] = {}
 
@@ -271,13 +268,13 @@ def _find_path_from_directory(
 
             # only load dag files that are already migrated
             # work around for poor negative look back regex performance
-            if service_instance == 'production' or service_instance == 'staging':
+            if service_instance == 'production':
                 # temp patch to load new Flyte workflows into Airflow 2 to unblock initial migration users
                 # this will be replaced soon with look-up tables for mult-cluster Airflow
                 dag_repo = str(abs_file_path).split("/")[4]
                 if not (is_airflow_dev_env or is_loadtest_env) and \
                    dag_repo not in MIGRATED_FLYTE_REPOS and \
-                   str(abs_file_path) not in migrated_dags_set:
+                   str(abs_file_path) not in MIGRATED_DAG_FILES:
                     continue
 
             yield str(abs_file_path)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post12'
+version = '2.3.4.post13'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
What:
Load all DAGs into Airflow 2 staging 

Why:
We shut down Airflow 1 staging to unblock omnicron-staging cluster shutting down so there's just a single Airflow staging cluster running.

Testing:
Branch deploy to Airflow 2 staging

Follow ups:
This process will be updates next week with utilizing look up tables as opposed to statically set files w/ adjoining canaries.