### PR TITLE
add missing AirflowFailException import

### DIFF
--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -26,6 +26,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import Session, reconstructor, synonym
 
 from airflow.configuration import ensure_secrets_loaded
+from airflow.exceptions import AirflowFailException
 from airflow.models.base import ID_LEN, Base
 from airflow.models.crypto import get_fernet
 from airflow.secrets.metastore import MetastoreBackend

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post13'
+version = '2.3.4.post14'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
This was caught when I was adding some unit tests to python-lyft-etl. This wouldn't have impacted workflows as the error of missing import would have come up when we're intentionally bubbling up a failure + we didn't roll out those changes to our Airflow cluster.

This should've been caught by unit tests here in test_variable.py (those unit tests would also need to be updated with the Variable.set(...) change). However, we don't run these unit tests on builds. 

Follow up work:
Run these unit tests as part of builds. If it's too much to set this up on Lyft infra w/ this open source branch, we could get a non-packaged version of this code and run as part of builds in airflowinfra2. 