### PR TITLE
do not check for infinite recursion on TARS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post14'
+version = '2.3.4.post15'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
This fixes the ongoing issue w/ file trawls on TARS. In the past, we made the change on the pod itself as we hoped TARS would be deprecated by now.