### PR TITLE
Move airflowinfra import into production env path

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -89,8 +89,6 @@ class DagBag(BaseDagBag, LoggingMixin):
             safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
             store_serialized_dags=False,
     ):
-        from airflowinfra.multi_cluster_utils import fetch_dags_in_cluster
-
         # do not use default arg in signature, to fix import cycle on plugin load
         if executor is None:
             executor = get_default_executor()
@@ -100,6 +98,8 @@ class DagBag(BaseDagBag, LoggingMixin):
 
         # if this fetch fails, then so will this DagBag init process
         if self.service_instance == 'production':
+
+            from airflowinfra.multi_cluster_utils import fetch_dags_in_cluster
             self.cluster_dags = fetch_dags_in_cluster()
 
         self.dag_folder = dag_folder
@@ -221,7 +221,6 @@ class DagBag(BaseDagBag, LoggingMixin):
         the module and look for dag objects within it.
         """
         from airflow.models.dag import DAG  # Avoid circular import
-        from airflowinfra.multi_cluster_utils import _dag_in_migrated_flyte_repo
 
         found_dags = []
 
@@ -324,6 +323,8 @@ class DagBag(BaseDagBag, LoggingMixin):
                     # When in production, restrict the DagBag 
                     # to the appropriate set of DAGs.
                     if self.service_instance == 'production':
+
+                        from airflowinfra.multi_cluster_utils import _dag_in_migrated_flyte_repo
 
                         if not self.cluster_dags:
                             raise AirflowFailException

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.15.post4'
+version = '1.10.15.post5'


### PR DESCRIPTION
This ensures that the code is not executed as part of CI. 