### PR TITLE
Move import of airflowinfra to only in production

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -102,7 +102,6 @@ class DagBag(LoggingMixin):
     ):
         # Avoid circular import
         from airflow.models.dag import DAG
-        from airflowinfra.multi_cluster_utils import fetch_dags_in_cluster
 
         super().__init__()
 
@@ -121,6 +120,8 @@ class DagBag(LoggingMixin):
         
         # if this fetch fails, then so will this DagBag init process
         if self.service_instance == 'production':
+
+            from airflowinfra.multi_cluster_utils import fetch_dags_in_cluster
             self.cluster_dags = fetch_dags_in_cluster()
         
         self.dag_folder = dag_folder
@@ -404,7 +405,6 @@ class DagBag(LoggingMixin):
 
     def _process_modules(self, filepath, mods, file_last_changed_on_disk):
         from airflow.models.dag import DAG  # Avoid circular import
-        from airflowinfra.multi_cluster_utils import _dag_in_migrated_flyte_repo
 
         top_level_dags = ((o, m) for m in mods for o in m.__dict__.values() if isinstance(o, DAG))
 
@@ -417,6 +417,8 @@ class DagBag(LoggingMixin):
             # to the appropriate set of DAGs.
             if self.service_instance == 'production':
 
+                from airflowinfra.multi_cluster_utils import _dag_in_migrated_flyte_repo
+                
                 if not self.cluster_dags:
                     raise AirflowFailException
                 # Do not load DAGs that are missing from the DAG mapping table 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post18'
+version = '2.3.4.post19'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
This change will ensure that airflowinfra is not imported as part of CI checks