### PR TITLE
Do not restrict dagbag in kyte or tars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post20'
+version = '2.3.4.post22'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
Because Kyte and Tars run as production instances, we need to ensure make sure that they do not have any dag bag restriction based on the cluster (Kyte and TARS will always run on the default cluster, which will not contain all DAGs).