### PR TITLE
[DATAOR-1054] Fix Task Instances UI tab. 

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5008,8 +5008,14 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
 
     class_permission_name = permissions.RESOURCE_TASK_INSTANCE
     method_permission_name = {
-        'list': 'read',
-        'action_muldelete': 'delete',
+        "list": "read",
+        "action_clear": "edit",
+        "action_muldelete": "delete",
+        "action_set_running": "edit",
+        "action_set_failed": "edit",
+        "action_set_success": "edit",
+        "action_set_retry": "edit",
+        "action_set_skipped": "edit",
     }
     base_permissions = [
         permissions.ACTION_CAN_CREATE,

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post22'
+version = '2.3.4.post23'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
[DATAOR-1054] Fix Task Instances UI tab. Extend method_permission_name based on Airflow latest OSS version

**Context:** 
It seems that we are missing some method names in method_permission_name array that doesn't allow a user to do actions like "Clear", "Set to 'failed'", e.t.c on the Airflow / Task Instances page. 

**Airflow latest OSS version:** 
https://github.com/apache/airflow/blob/8e738cd0ad0e7dce644f66bb749a7b46770badee/airflow/www/views.py#L5581

**JIRA ticket:** 
https://jira.lyft.net/browse/DATAOR-1054
