### PR TITLE
Romansviastyn/fix webpack license plugin to 422

### DIFF
--- a/airflow/www/package.json
+++ b/airflow/www/package.json
@@ -72,7 +72,7 @@
     "url-loader": "4.1.0",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.0.0",
-    "webpack-license-plugin": "4.2.2",
+    "webpack-license-plugin": "^4.2.2",
     "webpack-manifest-plugin": "^4.0.0"
   },
   "dependencies": {

--- a/airflow/www/package.json
+++ b/airflow/www/package.json
@@ -72,7 +72,7 @@
     "url-loader": "4.1.0",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.0.0",
-    "webpack-license-plugin": "^4.2.1",
+    "webpack-license-plugin": "4.2.2",
     "webpack-manifest-plugin": "^4.0.0"
   },
   "dependencies": {

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post23'
+version = '2.3.4.post24'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
Fix Airflow UI npm module `webpack-license-plugin` to 4.2.2 as yesterday it got new release 4.3.0 that requires node16 but we are using node14.