### PR TITLE
Remove error message for multi cluster

### DIFF
--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -168,9 +168,6 @@ class Variable(Base, LoggingMixin):
         :param session: SQL Alchemy Sessions
         :param is_multi_cluster_enabled: is set wrapped by lyft-etl sync_variable_writes_multicluster
         """
-        if not is_multi_cluster_enabled:
-            raise AirflowFailException("Please write Airflow variables using "
-                                       "sync_variable_writes_multicluster defined in lyft-etl")
         # check if the secret exists in the custom secrets backend.
         cls.check_for_write_conflict(key)
         if serialize_json:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post32'
+version = '2.3.4.post33'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
https://jira.lyft.net/browse/DATAOR-1218
https://lyft.slack.com/archives/CA4HS7D8V/p1708472176710349

We previously had this change to sync variables in both airflow 1 and 2 during airflow migration. Since migration is over, we no longer need to sync variables, thus removing the error message here.