### PR TITLE
SLA miss duplicate notification

### DIFF
--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -501,6 +501,11 @@ class DagFileProcessor(LoggingMixin):
                         emails |= set(get_email_address_list(task.email))
                     elif isinstance(task.email, (list, tuple)):
                         emails |= set(task.email)
+
+            # Do not send Emails to Pagerduty to avoid double Page creation
+            if dag.sla_miss_callback:
+                emails = {email for email in emails if not email.endswith('@lyft.pagerduty.com')}
+
             if emails:
                 try:
                     send_email(emails, f"[airflow] SLA miss on DAG={dag.dag_id}", email_content)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post34'
+version = '2.3.4.post35'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
PagerDuty can create pages via email or API call.
We have Notifiers defined that work as **sla_miss_callback** and are called when an SLA misses, they call PagerDuty pages with the API. 
Airflow also sends emails when the SLA is missed, to all the emails defined in the DAG, so when PagerDuty gets that email, it creates a new Page, so we end up with 2 pages for the same DAG SLA miss.

The solution to this is quite simple. If there is a callback defined in **sla_miss_callback**, then we won't send the email to the @lyft.pagerduty.com emails.


simple unit test of the change applied:
```
test_emails = {'email@correo.com', 'email@lyft.pagerduty.com', 'email@pagerduty.com'}
emails = {email for email in test_emails if not email.endswith('@lyft.pagerduty.com')}
assert(emails == {'email@correo.com', 'email@pagerduty.com'})
```